### PR TITLE
Added /price command to fetch and display the current DEV token price.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "discord-bot-skeleton",
+  "name": "dev-bot",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "discord-bot-skeleton",
+      "name": "dev-bot",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@logtail/pino": "^0.4.20",
         "discord.js": "^14.7.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ async function handleInteractionCommands(
   if (commandName === "ping") {
     await interaction.reply("Pong!");
   }
-  if (commandName === "price") {    
+  else if (commandName === "price") {    
     const tokenData = await fetchTokenPrice("scout-protocol-token");
 
     if (tokenData) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
 } from "discord.js";
 import logger from "./utils/logger";
 import { startDevPriceUpdateJob } from "./cron/priceUpdateJob";
+import { fetchTokenPrice } from "./utils/coinGecko";
 
 const token: string | undefined = process.env.DISCORD_TOKEN;
 
@@ -31,6 +32,10 @@ const commandsData: ApplicationCommandDataResolvable[] = [
   new SlashCommandBuilder()
     .setName("ping")
     .setDescription("Replies with Pong!")
+    .toJSON(),
+  new SlashCommandBuilder()
+    .setName("price")
+    .setDescription("Fetches and displays the current DEV token price.")
     .toJSON(),
 ];
 
@@ -58,6 +63,17 @@ async function handleInteractionCommands(
 
   if (commandName === "ping") {
     await interaction.reply("Pong!");
+  }
+  if (commandName === "price") {    
+    const tokenData = await fetchTokenPrice("scout-protocol-token");
+
+    if (tokenData) {
+      const price = tokenData.usd;
+      const replyMessage = `**DEV Token Price:** $${price.toFixed(5)}\n`;                           
+      await interaction.reply(replyMessage);
+    } else {
+      await interaction.reply("Sorry, I couldn't fetch the price right now. Please try again later.");
+    }
   }
 }
 


### PR DESCRIPTION
## ✨ New Feature: Add `/price` Slash Command

**Context:**
This PR introduces a new slash command `/price` to allow users to quickly fetch and display the current price information for the DEV token.

**Changes Implemented:**

*   **Added `/price` Command:**
    *   Registered a new slash command named `price` with the description "Fetches and displays the current DEV token price." in `src/index.ts`.
*   **Command Handling:**
    *   Implemented the logic for the `/price` command within the `handleInteractionCommands` function in `src/index.ts`.
    *   The handler calls the `fetchTokenPrice` function (from `src/utils/coinGecko.ts`) to retrieve data for the "scout-protocol-token".
    *   On successful data retrieval, it formats and sends a reply to the Discord interaction including:
        *   Current DEV token price (USD, fixed to 5 decimal places).
*   **Imports:**
    *   Imported `fetchTokenPrice` from `src/utils/coinGecko.ts` into `src/index.ts`.
*   **Error Handling:**
    *   If `fetchTokenPrice` returns `null` (i.e., fails to fetch data), the command replies with a user-friendly message: "Sorry, I couldn't fetch the price right now. Please try again later."

**How to Test:**

1.  Ensure the bot is running.
2.  In a Discord server where the bot is present, type `/price`.
3.  Verify that the bot replies with the current DEV token price.


This enhancement provides users with easy access to important token metrics directly within Discord.