### PR TITLE
Add `/uniswap` command to return the Uniswap link for the token in Discord interactions.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
 import logger from "./utils/logger";
 import { startDevPriceUpdateJob } from "./cron/priceUpdateJob";
 import { fetchTokenPrice } from "./utils/coinGecko";
+import { UNISWAP_LINK } from "./utils/constants";
 
 const token: string | undefined = process.env.DISCORD_TOKEN;
 
@@ -37,6 +38,11 @@ const commandsData: ApplicationCommandDataResolvable[] = [
     .setName("price")
     .setDescription("Fetches and displays the current DEV token price.")
     .toJSON(),
+  new SlashCommandBuilder()
+    .setName("uniswap")
+    .setDescription("Returns the Uniswap link for the token.")
+    .toJSON(),
+
 ];
 
 async function createDiscordServer(): Promise<Client> {
@@ -74,6 +80,9 @@ async function handleInteractionCommands(
     } else {
       await interaction.reply("Sorry, I couldn't fetch the price right now. Please try again later.");
     }
+  }
+  else if (commandName === "uniswap") {
+    await interaction.reply(UNISWAP_LINK);
   }
 }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const UNISWAP_LINK = "https://app.uniswap.org/explore/tokens/base/0x047157cffb8841a64db93fd4e29fa3796b78466c";


### PR DESCRIPTION
##  New `/uniswap` Command 

**Summary:**
This PR introduces a new `/uniswap` slash command that provides users with a direct link to the DEV token on Uniswap.

**Key Changes:**

*   **New `/uniswap` Command:** Added a command to display the Uniswap link for the DEV token.
*   **Uniswap Link Constant:** The Uniswap URL is now managed as a shared constant in `src/utils/constants.ts`.

**Testing:**

1.  Run the bot.
2.  Test the `/uniswap` command to ensure it returns the correct Uniswap link.

This update improves how users access token information and makes the codebase more maintainable.