### PR TITLE
Added `/mcap` command to return the market cap of DEV token

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,10 @@ const commandsData: ApplicationCommandDataResolvable[] = [
     .setName("uniswap")
     .setDescription("Returns the Uniswap link for the token.")
     .toJSON(),
+  new SlashCommandBuilder()
+    .setName("mcap")
+    .setDescription("Returns the market cap of the token.")
+    .toJSON(),
 
 ];
 
@@ -83,6 +87,15 @@ async function handleInteractionCommands(
   }
   else if (commandName === "uniswap") {
     await interaction.reply(UNISWAP_LINK);
+  }
+  else if (commandName === "mcap") {
+    const tokenData = await fetchTokenPrice("scout-protocol-token");
+    if (tokenData) {
+      const replyMessage = `**DEV Token Market Cap:** $${tokenData.usd_market_cap?.toFixed(2)}`;
+      await interaction.reply(replyMessage);
+    } else {
+      await interaction.reply("Sorry, I couldn't fetch the market cap right now. Please try again later.");
+    }
   }
 }
 

--- a/src/utils/coinGecko.ts
+++ b/src/utils/coinGecko.ts
@@ -16,6 +16,7 @@ interface CoinGeckoPriceDetail {
   usd: number;
   usd_24h_vol?: number;
   usd_24h_change?: number;
+  usd_market_cap?: number;
 }
 
 interface CoinGeckoPriceResponse {
@@ -35,7 +36,7 @@ if (!COINGECKO_API_KEY) {
  * @returns The price data including USD price, 24h volume, and 24h change
  */
 export async function fetchTokenPrice(tokenId: string): Promise<CoinGeckoPriceDetail | null> {
-    const url = `https://api.coingecko.com/api/v3/simple/price?vs_currencies=usd&ids=${tokenId}&include_24hr_vol=true&include_24hr_change=true&precision=5`;
+    const url = `https://api.coingecko.com/api/v3/simple/price?vs_currencies=usd&ids=${tokenId}&include_market_cap=true&include_24hr_vol=true&include_24hr_change=true&precision=5`;
     const options = {
         method: 'GET',
         headers: {


### PR DESCRIPTION
**New Addition**
This PR adds `/mcap` command to return the market cap of DEV token

**Updated**
This PR updates the fetch URL to include market cap data