### PR TITLE
feature: added `/create-price-alert` command

### DIFF
--- a/src/alertCommands/createPriceAlert.ts
+++ b/src/alertCommands/createPriceAlert.ts
@@ -1,0 +1,75 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction, InteractionResponseType } from "discord.js";
+import logger from "../utils/logger";
+import { PrismaClient } from "../generated/prisma";
+
+
+const prisma = new PrismaClient();
+
+export const createPriceAlertCommand = new SlashCommandBuilder()
+  .setName("create-price-alert")
+  .setDescription("Creates a price alert for the DEV token.")
+  .addStringOption(option =>
+    option.setName("direction")
+      .setDescription("Price direction to alert on")
+      .setRequired(true)
+      .addChoices(
+        { name: 'Up', value: 'up' },
+        { name: 'Down', value: 'down' },
+      ))
+  .addNumberOption(option =>
+    option.setName("value")
+      .setDescription("The price value to alert at")
+      .setRequired(true))
+  .toJSON();
+
+export async function handleCreatePriceAlert(interaction: ChatInputCommandInteraction) {
+  const direction = interaction.options.getString("direction", true) as 'up' | 'down';
+  const value = interaction.options.getNumber("value", true);
+  const { guildId, channelId } = interaction;
+
+  if (!guildId) {
+    await interaction.reply({ 
+      content: "This command can only be used in a server.", 
+      flags: 64 // Ephemeral flag
+    });
+    return;
+  }
+
+  if (!channelId) {
+    await interaction.reply({ 
+      content: "This command can only be used in a channel.", 
+      flags: 64 // Ephemeral flag
+    });
+    return;
+  }
+
+  try {
+    // Ensure server exists and is up to date
+    const server = await prisma.discordServer.upsert({
+      where: { id: guildId },
+      update: { name: interaction.guild?.name },
+      create: { id: guildId, name: interaction.guild?.name }
+    });
+
+    // Create the Alert with nested PriceAlert creation
+    await prisma.alert.create({
+      data: {
+        channelId: channelId,
+        enabled: true,
+        discordServerId: server.id,
+        priceAlert: {
+          create: {
+            direction: direction,
+            value: value
+          }
+        }
+      }
+    });
+
+    const directionEmoji = direction === 'up' ? '📈' : '📉';
+    await interaction.reply(`✅ Alert created! I will notify you in this channel when the price goes ${direction} $${value}. ${directionEmoji}`);
+  } catch (error) {
+    logger.error("Error creating price alert:", error);
+    await interaction.reply("Sorry, I couldn't create the price alert. Please try again later.");
+  }
+}

--- a/src/alertCommands/createPriceAlert.ts
+++ b/src/alertCommands/createPriceAlert.ts
@@ -1,9 +1,7 @@
 import { SlashCommandBuilder, ChatInputCommandInteraction, InteractionResponseType } from "discord.js";
 import logger from "../utils/logger";
-import { PrismaClient } from "../generated/prisma";
+import prisma from "../utils/prisma";
 
-
-const prisma = new PrismaClient();
 
 export const createPriceAlertCommand = new SlashCommandBuilder()
   .setName("create-price-alert")

--- a/src/alertCommands/createPriceAlert.ts
+++ b/src/alertCommands/createPriceAlert.ts
@@ -1,6 +1,8 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction, InteractionResponseType } from "discord.js";
+import { SlashCommandBuilder, ChatInputCommandInteraction } from "discord.js";
 import logger from "../utils/logger";
 import prisma from "../utils/prisma";
+import { fetchTokenPrice } from "../utils/coinGecko";
+
 
 
 export const createPriceAlertCommand = new SlashCommandBuilder()
@@ -42,30 +44,38 @@ export async function handleCreatePriceAlert(interaction: ChatInputCommandIntera
   }
 
   try {
-    // Ensure server exists and is up to date
-    const server = await prisma.discordServer.upsert({
-      where: { id: guildId },
-      update: { name: interaction.guild?.name },
-      create: { id: guildId, name: interaction.guild?.name }
-    });
+    await prisma.$transaction(async (prisma) => {
+      // Ensure server exists and is up to date
+      const server = await prisma.discordServer.upsert({
+        where: { id: guildId },
+        update: { name: interaction.guild?.name },
+        create: { id: guildId, name: interaction.guild?.name }
+      });
 
-    // Create the Alert with nested PriceAlert creation
-    await prisma.alert.create({
-      data: {
-        channelId: channelId,
-        enabled: true,
-        discordServerId: server.id,
-        priceAlert: {
-          create: {
-            direction: direction,
-            value: value
+      // Create the Alert with nested PriceAlert creation
+      await prisma.alert.create({
+        data: {
+          channelId: channelId,
+          enabled: true,
+          discordServerId: server.id,
+          priceAlert: {
+            create: {
+              direction: direction,
+              value: value
+            }
           }
         }
-      }
+      });
     });
 
     const directionEmoji = direction === 'up' ? '📈' : '📉';
-    await interaction.reply(`✅ Alert created! I will notify you in this channel when the price goes ${direction} $${value}. ${directionEmoji}`);
+    const tokenData = await fetchTokenPrice("scout-protocol-token");
+    if (tokenData) {
+      const price = tokenData.usd;
+      await interaction.reply(`✅ Alert created! I will notify you in this channel when the price goes ${direction} to $${value}. ${directionEmoji}, the current DEV price is $${price} `);
+    } else {
+      await interaction.reply("Sorry, I couldn't fetch the token price right now. Please try again later.");
+    }
   } catch (error) {
     logger.error("Error creating price alert:", error);
     await interaction.reply("Sorry, I couldn't create the price alert. Please try again later.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import logger from "./utils/logger";
 import { startDevPriceUpdateJob } from "./cron/priceUpdateJob";
 import { fetchTokenPrice, formatNumber } from "./utils/coinGecko";
 import { UNISWAP_LINK } from "./utils/constants";
+import { createPriceAlertCommand ,handleCreatePriceAlert} from "./alertCommands/createPriceAlert";
 
 const token: string | undefined = process.env.DISCORD_TOKEN;
 
@@ -62,6 +63,7 @@ const commandsData: ApplicationCommandDataResolvable[] = [
         .setDescription("The amount of DEV tokens")
         .setRequired(true))
     .toJSON(),
+  createPriceAlertCommand,
 ];
 
 async function createDiscordServer(): Promise<Client> {
@@ -144,6 +146,9 @@ async function handleInteractionCommands(
     } else {
       await interaction.reply("Sorry, I couldn't fetch the token price right now. Please try again later.");
     }
+  }
+  else if (commandName === "create-price-alert") {
+    await handleCreatePriceAlert(interaction);
   }
 }
 

--- a/src/utils/prisma.ts
+++ b/src/utils/prisma.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from "../generated/prisma";
+
+const prisma = new PrismaClient();
+
+export default prisma; 


### PR DESCRIPTION
# Price Alert Command

Added `/create-price-alert` command that lets users set price alerts for DEV token. Users can specify target price and direction (up/down) to receive notifications.

## Changes
- New `/create-price-alert` slash command
- Added a new directory `src/alertCommands` for better organization of the code.

## Testing
- [x] Alert creation with valid/invalid parameters
- [x] Error handling

Note: Price alert notifications to be implemented in future PR