### PR TITLE
feat: added `/edit-price-alert` command to modify existing price alerts

### DIFF
--- a/src/alertCommands/editPriceAlert.ts
+++ b/src/alertCommands/editPriceAlert.ts
@@ -1,0 +1,105 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  PermissionFlagsBits,
+} from "discord.js";
+import logger from "../utils/logger";
+import prisma from "../utils/prisma";
+import { PriceAlertDirection } from "../generated/prisma/client";
+
+export const editPriceAlertCommand = new SlashCommandBuilder()
+  .setName("edit-price-alert")
+  .setDescription("Edits an existing price alert.")
+  .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
+  .addStringOption((option) =>
+    option
+      .setName("id")
+      .setDescription("The ID of the alert to edit.")
+      .setRequired(true)
+  )
+  .addStringOption((option) =>
+    option
+      .setName("direction")
+      .setDescription("The new price direction to alert on.")
+      .setRequired(false)
+      .addChoices({ name: "Up", value: "up" }, { name: "Down", value: "down" })
+  )
+  .addNumberOption((option) =>
+    option
+      .setName("value")
+      .setDescription("The new price value to alert at.")
+      .setRequired(false)
+  )
+  .toJSON();
+
+export async function handleEditPriceAlert(
+  interaction: ChatInputCommandInteraction
+): Promise<void> {
+  const alertId = interaction.options.getString("id", true);
+  const newDirection = interaction.options.getString("direction") as PriceAlertDirection | null;
+  const newValue = interaction.options.getNumber("value");
+  const { guildId, channelId } = interaction;
+
+  if (!guildId || !channelId) {
+    await interaction.reply({
+      content: "This command can only be used in a server channel.",
+      flags: 64,
+    });
+    return;
+  }
+
+  if (!newDirection && newValue === null) {
+    await interaction.reply({
+      content: "You must provide a new direction or a new value to update.",
+      flags: 64,
+    });
+    return;
+  }
+
+  try {
+    const alert = await prisma.alert.findUnique({
+      where: {
+        id: alertId,
+        discordServerId: guildId,
+        channelId: channelId,
+      },
+      include: {
+        priceAlert: true,
+      },
+    });
+
+    if (!alert || !alert.priceAlert) {
+      await interaction.reply({
+        content: "Price alert not found or you do not have permission to edit it in this channel.",
+        flags: 64,
+      });
+      return;
+    }
+
+    const updateData: { direction?: PriceAlertDirection; value?: number } = {};
+    if (newDirection) {
+      updateData.direction = newDirection;
+    }
+    if (newValue !== null) {
+      updateData.value = newValue;
+    }
+
+    await prisma.priceAlert.update({
+      where: {
+        id: alert.priceAlert.id,
+      },
+      data: updateData,
+    });
+
+    await interaction.reply({
+      content: `✅ Successfully updated alert with ID: \`${alertId}\`.`,
+      flags: 64,
+    });
+  } catch (error) {
+    logger.error("Error editing price alert:", error);
+    await interaction.reply({
+      content: "Sorry, there was an error editing the price alert.",
+      flags: 64,
+    });
+  }
+} 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,10 @@ import {
   listPriceAlertsCommand,
   handleListPriceAlerts,
 } from "./alertCommands/listPriceAlerts";
+import {
+  editPriceAlertCommand,
+  handleEditPriceAlert,
+} from "./alertCommands/editPriceAlert";
 
 import { getDevPrice } from "./utils/uniswapPrice";
 
@@ -80,6 +84,7 @@ const commandsData: ApplicationCommandDataResolvable[] = [
     .toJSON(),
   createPriceAlertCommand,
   listPriceAlertsCommand,
+  editPriceAlertCommand,
 ];
 
 async function createDiscordServer(): Promise<Client> {
@@ -191,6 +196,8 @@ async function handleInteractionCommands(
     await handleCreatePriceAlert(interaction);
   } else if (commandName === "list-alerts") {
     await handleListPriceAlerts(interaction);
+  } else if (commandName === "edit-price-alert") {
+    await handleEditPriceAlert(interaction);
   }
 }
 


### PR DESCRIPTION
**Description:**
This PR introduces the `/edit-price-alert` command, allowing users to modify existing price alerts. The command supports updating the alert's direction and/or value. It includes permission checks to ensure only users with the ManageChannels permission can execute the command. Error handling is implemented to manage cases where the alert is not found or if the user lacks the necessary permissions.

- Resolves : #29 